### PR TITLE
System0 Subinterface prefix count

### DIFF
--- a/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
+++ b/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
@@ -58,21 +58,21 @@ module sdcio-srl-if-ip-deviations {
     }
   }
 
-  deviation "/srl_nokia-if:interface/srl_nokia-if:subinterface/srl_nokia-if:ipv4/srl_nokia-if:address" {
+  deviation "/srl_nokia-if:interface/srl_nokia-if:subinterface/srl_nokia-if:ipv4" {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) <= 1" {
+      must "not(../../srl_nokia-if:name = 'system0') or count(./srl_nokia-if:address) <= 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }
   }
 
-  deviation "/srl_nokia-if:interface/srl_nokia-if:subinterface/srl_nokia-if:ipv6/srl_nokia-if:address" {
+  deviation "/srl_nokia-if:interface/srl_nokia-if:subinterface/srl_nokia-if:ipv6" {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) <= 1" {
+      must "not(../../srl_nokia-if:name = 'system0') or count(./srl_nokia-if:address) <= 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }

--- a/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
+++ b/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
@@ -62,7 +62,7 @@ module sdcio-srl-if-ip-deviations {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../name = 'system0') or count(.) = 1" {
+      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) = 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }
@@ -72,7 +72,7 @@ module sdcio-srl-if-ip-deviations {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../name = 'system0') or count(.) = 1" {
+      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) = 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }

--- a/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
+++ b/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
@@ -62,7 +62,7 @@ module sdcio-srl-if-ip-deviations {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../srl_nokia-if:name = 'system0') or count(./srl_nokia-if:ip-prefix) = 1" {
+      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) <= 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }
@@ -72,7 +72,7 @@ module sdcio-srl-if-ip-deviations {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../srl_nokia-if:name = 'system0') or count(./srl_nokia-if:ip-prefix) = 1" {
+      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) <= 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }

--- a/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
+++ b/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
@@ -57,4 +57,24 @@ module sdcio-srl-if-ip-deviations {
       }
     }
   }
+
+  deviation "/srl_nokia-if:interface/srl_nokia-if:subinterface/srl_nokia-if:ipv4/srl_nokia-if:address" {
+    description
+      "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
+    deviate add {
+      must "not(../../../name = 'system0') or count(.) = 1" {
+        error-message "Only a single prefix is allowed when the interface name is system0.";
+      }
+    }
+  }
+
+  deviation "/srl_nokia-if:interface/srl_nokia-if:subinterface/srl_nokia-if:ipv6/srl_nokia-if:address" {
+    description
+      "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
+    deviate add {
+      must "not(../../../name = 'system0') or count(.) = 1" {
+        error-message "Only a single prefix is allowed when the interface name is system0.";
+      }
+    }
+  }
 }

--- a/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
+++ b/srl_nokia/models/interfaces/srl_nokia-if-ip-deviations.yang
@@ -62,7 +62,7 @@ module sdcio-srl-if-ip-deviations {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) = 1" {
+      must "not(../../../srl_nokia-if:name = 'system0') or count(./srl_nokia-if:ip-prefix) = 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }
@@ -72,7 +72,7 @@ module sdcio-srl-if-ip-deviations {
     description
       "Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.";
     deviate add {
-      must "not(../../../srl_nokia-if:name = 'system0') or count(../srl_nokia-if:address) = 1" {
+      must "not(../../../srl_nokia-if:name = 'system0') or count(./srl_nokia-if:ip-prefix) = 1" {
         error-message "Only a single prefix is allowed when the interface name is system0.";
       }
     }

--- a/srl_nokia/models/network-instance/srl_nokia-bgp-evpn-deviations.yang
+++ b/srl_nokia/models/network-instance/srl_nokia-bgp-evpn-deviations.yang
@@ -1,32 +1,35 @@
 module sdcio-srl_nokia-bgp-evpn-deviations {
-    yang-version 1.1;
-    namespace "urn:sdcio.dev:srlinux:net-inst:network-instance";
-    prefix sdcio-srl_nokia-bgp-evpn-deviations;
+  yang-version 1.1;
+  namespace "urn:sdcio.dev:srlinux:net-inst:network-instance";
+  prefix sdcio-srl_nokia-bgp-evpn-deviations;
 
-    import srl_nokia-network-instance {
-        prefix srl_nokia-netinst;
-    }
+  import srl_nokia-network-instance {
+    prefix srl_nokia-netinst;
+  }
+  import srl_nokia-bgp-vpn {
+    prefix srl_bgp-vpn;
+  }
 
-    organization
-      "Nokia";
-    contact
-      "SDCIO schema alterations
-       Web: <http://docs.sdcio.dev>";
+  organization
+    "Nokia";
+  contact
+    "SDCIO schema alterations
+     Web: <http://docs.sdcio.dev>";
 
-    revision 2025-03-06 {
-        description
-          "Initial deviation file.";
-        reference
-          "1.0.0";
-    }
+  revision 2025-03-06 {
+    description
+      "Initial deviation file.";
+    reference
+      "1.0.0";
+  }
 
   deviation "/srl_nokia-netinst:network-instance/srl_nokia-netinst:protocols/srl_nokia-netinst:bgp-evpn/srl_nokia-netinst:bgp-instance/srl_nokia-netinst:id" {
-    description "The original leafref is an absolute path. Which would then cover multiple network-instances, which is wrong. The id should exist in the local NI.";
+    description
+      "The original leafref is an absolute path. Which would then cover multiple network-instances, which is wrong. The id should exist in the local NI.";
     deviate replace {
       type leafref {
         path "../../../srl_bgp-vpn:bgp-vpn/srl_bgp-vpn:bgp-instance/srl_bgp-vpn:id";
       }
     }
   }
-
 }


### PR DESCRIPTION
Missing a check that for system0 interface only a single IP-Prefix is allowed per subinterface.